### PR TITLE
Rename accumulative helper functions

### DIFF
--- a/app/components/ui/orderbookAccordion.tsx
+++ b/app/components/ui/orderbookAccordion.tsx
@@ -8,8 +8,8 @@ import { FillBid } from "@/app/components/ui/fillBid";
 import { Badge } from "@/app/components/ui/badge";
 import {
   decimalToPercentage,
-  getAccumalativeValue,
-  getAccumalativeValueReverse,
+  getAccumulativeValue,
+  getAccumulativeValueReverse,
   toTwoDecimal,
 } from "@/utils/helpers";
 import { useContext, useEffect, useState } from "react";
@@ -468,7 +468,7 @@ const OrderbookAccordionContent = React.forwardRef<
                                         row, 
                                         bidOrAsk: "ask", 
                                         ordCost: Number(
-                                          getAccumalativeValueReverse(
+                                          getAccumulativeValueReverse(
                                             asks || [],
                                             orderBookLength - (index + 1)
                                           ) / 100
@@ -478,7 +478,7 @@ const OrderbookAccordionContent = React.forwardRef<
                                       <div className="w-[30%]">
                                         <FillAsk
                                           value={
-                                            (getAccumalativeValueReverse(
+                                            (getAccumulativeValueReverse(
                                               asks || [],
                                               orderBookLength - (index + 1)
                                             ) /
@@ -503,7 +503,7 @@ const OrderbookAccordionContent = React.forwardRef<
                                       <div className="w-[25%] text-center">
                                         {"$" +
                                           Number(
-                                            getAccumalativeValueReverse(
+                                            getAccumulativeValueReverse(
                                               asks || [],
                                               orderBookLength - (index + 1)
                                             ) / 100
@@ -561,7 +561,7 @@ const OrderbookAccordionContent = React.forwardRef<
                                         row, 
                                         bidOrAsk: "bid", 
                                         ordCost: Number(
-                                          getAccumalativeValue(
+                                          getAccumulativeValue(
                                             asks || [],
                                             orderBookLength - (index + 1)
                                           ) / 100
@@ -571,7 +571,7 @@ const OrderbookAccordionContent = React.forwardRef<
                                       <div className="w-[30%]">
                                         <FillBid
                                           value={
-                                            (getAccumalativeValue(
+                                            (getAccumulativeValue(
                                               bids || [],
                                               index
                                             ) /
@@ -596,7 +596,7 @@ const OrderbookAccordionContent = React.forwardRef<
                                       <div className="w-[25%] text-center">
                                         {"$" +
                                           Number(
-                                            getAccumalativeValue(
+                                            getAccumulativeValue(
                                               bids || [],
                                               index
                                             ) / 100

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -92,7 +92,7 @@ export function buyFunction(data, amountInUSD) {
   };
 }
 
-export const getAccumalativeValue = (arr, length) => {
+export const getAccumulativeValue = (arr, length) => {
   if (!Array.isArray(arr)) {
     return 0;
   }
@@ -104,7 +104,7 @@ export const getAccumalativeValue = (arr, length) => {
   return total;
 };
 
-export const getAccumalativeValueReverse = (arr, length) => {
+export const getAccumulativeValueReverse = (arr, length) => {
   if (!Array.isArray(arr)) {
     return 0;
   }


### PR DESCRIPTION
## Summary
- rename getAccumalativeValue -> getAccumulativeValue
- rename getAccumalativeValueReverse -> getAccumulativeValueReverse
- update OrderbookAccordion to import and use new names

## Testing
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689fcf5f1c908332bc57fdf00ec96433