### PR TITLE
Add guards for zero shares in helper functions

### DIFF
--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -44,6 +44,11 @@ export function sellFunction(data, sharesToSell) {
       remainingShares -= maxSharesForPrice;
     }
   }
+  
+  // Guard against division by zero when no shares are sold
+  if (totalSharesSold === 0) {
+    return { totalValue, averagePrice: 0 };
+  }
 
   const averagePrice = totalValue / totalSharesSold;
 
@@ -82,6 +87,11 @@ export function buyFunction(data, amountInUSD) {
       totalCost += maxSharesForPrice * price;
       remainingAmount -= maxSharesForPrice * price;
     }
+  }
+
+  // Guard against division by zero when no shares are bought
+  if (totalShares === 0) {
+    return { totalShares, averagePrice: 0 };
   }
 
   const averagePrice = totalCost / totalShares;


### PR DESCRIPTION
## Summary
- avoid NaN by guarding against division by zero in `sellFunction` and `buyFunction`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fd1315f088332b849526704553ce3