### PR TITLE
fix: guard array length in accumulative helpers

### DIFF
--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -96,9 +96,12 @@ export const getAccumulativeValue = (arr, length) => {
   if (!Array.isArray(arr)) {
     return 0;
   }
-  let arr2 = [...arr];
+  const arr2 = [...arr];
+  if (arr2.length < length + 1) {
+    return 0;
+  }
   let total = 0;
-  for (let i = 0; i < length + 1; i++) {
+  for (let i = 0; i < Math.min(length + 1, arr2.length); i++) {
     total += Number(arr2[i]?.[0]) * Number(arr2[i]?.[1]);
   }
   return total;
@@ -110,8 +113,11 @@ export const getAccumulativeValueReverse = (arr, length) => {
   }
   let arr2 = [...arr];
   arr2 = arr2.reverse();
+  if (arr2.length < length + 1) {
+    return 0;
+  }
   let total = 0;
-  for (let i = 0; i <= length; i++) {
+  for (let i = 0; i < Math.min(length + 1, arr2.length); i++) {
     total += Number(arr2[i]?.[0]) * Number(arr2[i]?.[1]);
   }
   return total;


### PR DESCRIPTION
## Summary
- avoid NaN in getAccumulativeValue and getAccumulativeValueReverse by checking array length and bounding loop iteration

## Testing
- `npm run build` (fails: Can't resolve '@/app/sonotrade.png')
- `npx tsc --noEmit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fd13976108332a25350107d119798